### PR TITLE
Change license to Apache 2.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,15 +1,17 @@
 /*
- * (C) Copyright 2014-2015 Kurento (http://kurento.org/)
+ * (C) Copyright 2013-2015 Kurento (http://kurento.org/)
  *
- * All rights reserved. This program and the accompanying materials are made
- * available under the terms of the GNU Lesser General Public License (LGPL)
- * version 2.1 which accompanies this distribution, and is available at
- * http://www.gnu.org/licenses/lgpl-2.1.html
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- * This library is distributed in the hope that it will be useful, but WITHOUT
- * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
- * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
- * details.
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 


### PR DESCRIPTION
According license file, 'Copyright' is under Kurento. Kurento is using Apache 2 license, so this file also should be Apache 2 license.

This commit is same content with following commit.
https://github.com/Kurento/kurento-client-js/commit/d6270c21c59c5f5d5ba9680a8506ce7c9cb0b5c2

Close: https://github.com/Kurento/bugtracker/issues/179
